### PR TITLE
Fix code scanning alert no. 45: Wrong type of arguments to formatting function

### DIFF
--- a/sdk/bta_usb.c
+++ b/sdk/bta_usb.c
@@ -1405,7 +1405,7 @@ static void *doDiscovery(void *handle) {
     libusb_context *context;
     int err = libusb_init(&context);
     if (err < 0) {
-        BTAinfoEventHelper(inst->infoEventInst, VERBOSE_ERROR, BTA_StatusRuntimeError, "Discovery: cannot init usb library, error: %d", libusb_error_name(err));
+        BTAinfoEventHelper(inst->infoEventInst, VERBOSE_ERROR, BTA_StatusRuntimeError, "Discovery: cannot init usb library, error: %s", libusb_error_name(err));
         return 0;
     }
     libusb_device **devs = 0;


### PR DESCRIPTION
Fixes [https://github.com/voxel-dot-at/becom-bta-lib/security/code-scanning/45](https://github.com/voxel-dot-at/becom-bta-lib/security/code-scanning/45)

To fix the problem, we need to change the format specifier from `%d` to `%s` to correctly match the type of the argument returned by `libusb_error_name`. This change ensures that the string returned by `libusb_error_name` is correctly formatted and displayed.

- Change the format specifier from `%d` to `%s` in the `BTAinfoEventHelper` function call on line 1408.
- No additional methods, imports, or definitions are needed to implement this change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
