### PR TITLE
Fix code scanning alert no. 42: Wrong type of arguments to formatting function

### DIFF
--- a/sdk/bta_grabbing.c
+++ b/sdk/bta_grabbing.c
@@ -221,7 +221,7 @@ static void *grabRunFunction(void *handle) {
                     BTAfLargeClose(file);
                     return 0;
                 }
-                BTAinfoEventHelper(inst->infoEventInst, VERBOSE_DEBUG, BTA_StatusInformation, "Grabbing: compressed bltframe %d : %d = %f%% in %dms", dstLen, frameSerializedLen, (float)dstLen / frameSerializedLen * 100.0f, timeEnd - timeStart);
+                BTAinfoEventHelper(inst->infoEventInst, VERBOSE_DEBUG, BTA_StatusInformation, "Grabbing: compressed bltframe %d : %d = %f%% in %lums", dstLen, frameSerializedLen, (float)dstLen / frameSerializedLen * 100.0f, timeEnd - timeStart);
                 frameSerialized = frameSerializedCompressed;
                 frameSerializedLen = dstLen;
             }


### PR DESCRIPTION
Fixes [https://github.com/voxel-dot-at/becom-bta-lib/security/code-scanning/42](https://github.com/voxel-dot-at/becom-bta-lib/security/code-scanning/42)

To fix the problem, we need to update the format specifier in the `printf`-like function call to match the type of the arguments. Since `timeEnd` and `timeStart` are likely `uint64_t` or `unsigned long`, we should use the `%lu` format specifier for `unsigned long`.

- Change the format specifier from `%d` to `%lu` for the `timeEnd - timeStart` argument.
- Ensure that the change is made only in the relevant line to avoid altering the existing functionality.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
